### PR TITLE
兼容DJI 导出的动态照片，修复动图播放真实时间

### DIFF
--- a/JarkViewer/src/ImageDatabase.cpp
+++ b/JarkViewer/src/ImageDatabase.cpp
@@ -2977,6 +2977,51 @@ static size_t getVideoSize(string_view exifStr) {
     return value;
 }
 
+// 某些厂商（如DJI）的实况照片会在视频数据后附加额外尾块，导致视频并不恰好位于文件末尾。
+// 在期望起点附近搜索合法的 MP4 'ftyp' 盒来定位真实视频起点；找不到则回退到原始切片。
+static std::span<const uint8_t> locateMotionPhotoVideo(std::span<const uint8_t> fileBuf, size_t videoSize) {
+    const size_t expectedStart = fileBuf.size() - videoSize;
+
+    auto isValidFtypBox = [&fileBuf](size_t boxStart) -> bool {
+        if (boxStart + 8 > fileBuf.size())
+            return false;
+        const uint8_t* p = fileBuf.data() + boxStart;
+        if (p[4] != 'f' || p[5] != 't' || p[6] != 'y' || p[7] != 'p')
+            return false;
+        const uint32_t boxSize = (uint32_t(p[0]) << 24) | (uint32_t(p[1]) << 16) | (uint32_t(p[2]) << 8) | uint32_t(p[3]);
+        return boxSize >= 8 && boxSize <= 4096 && boxStart + boxSize <= fileBuf.size();
+    };
+
+    if (isValidFtypBox(expectedStart)) // 起点已经对齐，无需修正
+        return fileBuf.subspan(expectedStart, videoSize);
+
+    constexpr size_t SEARCH_RANGE = 8192;
+    const size_t searchBegin = expectedStart > SEARCH_RANGE ? expectedStart - SEARCH_RANGE : 0;
+    const size_t searchEnd = std::min(expectedStart + SEARCH_RANGE, fileBuf.size() - 8);
+
+    size_t bestStart = std::numeric_limits<size_t>::max();
+    size_t bestDistance = std::numeric_limits<size_t>::max();
+    for (size_t pos = searchBegin; pos <= searchEnd; pos++) {
+        if (!isValidFtypBox(pos))
+            continue;
+        const size_t distance = pos > expectedStart ? pos - expectedStart : expectedStart - pos;
+        if (distance < bestDistance) { // 取距期望起点最近者
+            bestDistance = distance;
+            bestStart = pos;
+        }
+    }
+
+    if (bestStart == std::numeric_limits<size_t>::max()) {
+        JARK_LOG("MotionPhoto: MP4 start not found, fallback to the last {} bytes", videoSize);
+        return fileBuf.subspan(expectedStart, videoSize);
+    }
+
+    if (bestStart != expectedStart) {
+        JARK_LOG("MotionPhoto: adjust video start {} -> {} (videoSize: {})", expectedStart, bestStart, videoSize);
+    }
+    return fileBuf.subspan(bestStart, std::min(videoSize, fileBuf.size() - bestStart));
+}
+
 static std::vector<std::wstring> getVideoCandidatePaths(std::wstring_view imagePath) {
     const std::wstring fullPath(imagePath);
     const auto lastDot = fullPath.find_last_of(L'.');
@@ -3030,7 +3075,8 @@ ImageAsset ImageDatabase::loadMotionPhoto(wstring_view path, std::span<const uin
     auto videoSize = getVideoSize(exifInfo);
     std::vector<cv::Mat> frames;
     if (videoSize >= MIN_VIDEO_BUFF_SIZE && videoSize < fileBuf.size()) {
-        frames = DecodeVideoFrames(fileBuf.data() + fileBuf.size() - videoSize, videoSize);
+        auto videoBuf = locateMotionPhotoVideo(fileBuf, videoSize);
+        frames = DecodeVideoFrames(videoBuf.data(), videoBuf.size());
     }
     else {
         frames = decodeMotionPhotoSidecarVideo(path); // 苹果/VIVO等 独立视频文件的实况照片，尝试从同目录下的同名视频文件解码

--- a/JarkViewer/src/main.cpp
+++ b/JarkViewer/src/main.cpp
@@ -1626,6 +1626,7 @@ public:
     int64_t delayRemain = 0;
     const std::chrono::milliseconds frameDuration{ 10 };
     std::chrono::steady_clock::time_point lastTimestamp = std::chrono::steady_clock::now();
+    bool animClockArmed = false; // 动画计时器是否已启动(暂停/重新播放时需重新分配计时起点)
 
 
     void DrawScene() {
@@ -2094,8 +2095,12 @@ public:
         updateMainCanvas();
 
         if (curPar.imageAssetPtr->format == ImageFormat::Animated && curPar.isAnimationPause == false) {
-            if (delayRemain <= 0)
+            // 动画开始/恢复播放时重新确定计时起点，避免加载耗时或暂停时长被计入首帧
+            if (!animClockArmed) {
+                animClockArmed = true;
                 delayRemain = curPar.curFrameDelay;
+                lastTimestamp = std::chrono::steady_clock::now();
+            }
 
             auto nowTimestamp = std::chrono::steady_clock::now();
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(nowTimestamp - lastTimestamp);
@@ -2105,8 +2110,8 @@ public:
                 std::this_thread::sleep_for(frameDuration - elapsed);
 
             delayRemain -= elapsed.count();
-            if (delayRemain <= 0) {
-                delayRemain = curPar.curFrameDelay;
+            // 累进推进帧，并保留余量，保证按帧延迟的真实时间播放，避免越来越慢
+            while (delayRemain <= 0) {
                 curPar.curFrameIdx++;
                 if (curPar.curFrameIdx > curPar.curFrameIdxMax) {
                     curPar.curFrameIdx = 0;
@@ -2116,9 +2121,14 @@ public:
                         curPar.imageAssetPtr->format = ImageFormat::Still;
                         curPar.Init(winWidth, winHeight);
                         operateQueue.push({ ActionENUM::refresh });
+                        break;
                     }
                 }
+                delayRemain += std::max(1, curPar.imageAssetPtr->frameDurations[curPar.curFrameIdx]);
             }
+        }
+        else {
+            animClockArmed = false; // 暂停或非动画状态时作废旧计时起点
         }
     }
 

--- a/JarkViewer/src/videoDecoder.cpp
+++ b/JarkViewer/src/videoDecoder.cpp
@@ -314,17 +314,12 @@ std::vector<cv::Mat> DecodeVideoFrames(const uint8_t* videoBuffer, size_t size, 
         return frames;
     }
 
-    // 6. 准备颜色空间转换上下文 (YUV -> BGR)，并应用缩放
-    std::unique_ptr<SwsContext, SwsContextDeleter> swsCtx(sws_getContext(
-        srcWidth, srcHeight, codecCtx->pix_fmt,
-        dstWidth, dstHeight, AV_PIX_FMT_BGR24,
-        SWS_BILINEAR, nullptr, nullptr, nullptr
-    ));
-
-    if (!swsCtx) {
-        JARK_LOG("Failed to create SwsContext");
-        return frames;
-    }
+    // 6. 颜色空间转换上下文 (YUV -> BGR) 延迟到解码出首帧后创建：
+    //    部分码流在解码前无法确定像素格式 (codecCtx->pix_fmt == AV_PIX_FMT_NONE)，
+    //    直接用未知格式调用 sws_getContext 会触发 swscale 断言导致进程崩溃；
+    //    首帧的 frame->format 才是解码后实际可用的像素格式。
+    std::unique_ptr<SwsContext, SwsContextDeleter> swsCtx;
+    AVPixelFormat swsSrcFmt = AV_PIX_FMT_NONE;
 
     // 7. 准备帧和包
     std::unique_ptr<AVFrame, AvFrameDeleter> frame(av_frame_alloc());
@@ -359,59 +354,85 @@ std::vector<cv::Mat> DecodeVideoFrames(const uint8_t* videoBuffer, size_t size, 
     while (av_read_frame(formatCtx.get(), packet.get()) >= 0) {
         if (packet->stream_index == videoStreamIndex) {
             int sendResult = avcodec_send_packet(codecCtx.get(), packet.get());
-            if (sendResult < 0) {
+            if (sendResult < 0) { // 跳过损坏的数据包，继续尝试后续数据包
                 char errStr[AV_ERROR_MAX_STRING_SIZE] = { 0 };
                 JARK_LOG("Error sending packet: {}", av_make_error_string(errStr, sizeof(errStr), sendResult));
-                break;
             }
-
-            while (true) {
-                int receiveResult = avcodec_receive_frame(codecCtx.get(), frame.get());
-                if (receiveResult == AVERROR(EAGAIN) || receiveResult == AVERROR_EOF) {
-                    break;
-                }
-                else if (receiveResult < 0) {
-                    char errStr[AV_ERROR_MAX_STRING_SIZE] = { 0 };
-                    JARK_LOG("Error decoding frame: {}", av_make_error_string(errStr, sizeof(errStr), receiveResult));
-                    break;
-                }
-
-                // 9. 颜色转换 (YUV -> BGR) 并缩放
-                int scaledRows = sws_scale(swsCtx.get(), frame->data, frame->linesize, 0, srcHeight,
-                    rgbFrame->data, rgbFrame->linesize);
-                if (scaledRows <= 0) {
-                    JARK_LOG("Failed to convert video frame: {} rows scaled", scaledRows);
-                    continue;
-                }
-
-                // 10. 创建 cv::Mat (注意：OpenCV 使用 BGR)
-                // 数据是连续的，直接封装
-                cv::Mat decodedMat(dstHeight, dstWidth, CV_8UC3, rgbFrame->data[0]);
-
-                // 深拷贝数据，因为 rgbBuffer 会在下一帧被覆盖
-                cv::Mat finalMat = decodedMat.clone();
-
-                // 11. 处理旋转
-                if (rotation != 0) {
-                    int cvRotateCode = -1;
-                    int normRot = (rotation % 360 + 360) % 360;
-
-                    if (normRot == 90) {
-                        cvRotateCode = cv::ROTATE_90_CLOCKWISE;
+            else {
+                while (true) {
+                    int receiveResult = avcodec_receive_frame(codecCtx.get(), frame.get());
+                    if (receiveResult == AVERROR(EAGAIN) || receiveResult == AVERROR_EOF) {
+                        break;
                     }
-                    else if (normRot == 180) {
-                        cvRotateCode = cv::ROTATE_180;
-                    }
-                    else if (normRot == 270) {
-                        cvRotateCode = cv::ROTATE_90_COUNTERCLOCKWISE;
+                    else if (receiveResult < 0) {
+                        char errStr[AV_ERROR_MAX_STRING_SIZE] = { 0 };
+                        JARK_LOG("Error decoding frame: {}", av_make_error_string(errStr, sizeof(errStr), receiveResult));
+                        break;
                     }
 
-                    if (cvRotateCode >= 0) {
-                        cv::rotate(finalMat, finalMat, cvRotateCode);
+                    // 跳过无效帧或分辨率发生变化的帧（RGB 缓冲区按初始分辨率分配）
+                    if (frame->format == AV_PIX_FMT_NONE || frame->width <= 0 || frame->height <= 0) {
+                        JARK_LOG("Skip video frame with invalid format/size: fmt={} {}x{}",
+                            frame->format, frame->width, frame->height);
+                        continue;
                     }
-                }
+                    if (frame->width != srcWidth || frame->height != srcHeight) {
+                        JARK_LOG("Skip video frame with unexpected size: {}x{} (expected {}x{})",
+                            frame->width, frame->height, srcWidth, srcHeight);
+                        continue;
+                    }
 
-                frames.push_back(std::move(finalMat));
+                    // 9. 按需 (重)建颜色转换上下文 (YUV -> BGR) 并缩放
+                    auto srcFmt = static_cast<AVPixelFormat>(frame->format);
+                    if (!swsCtx || srcFmt != swsSrcFmt) {
+                        swsCtx.reset(sws_getContext(
+                            srcWidth, srcHeight, srcFmt,
+                            dstWidth, dstHeight, AV_PIX_FMT_BGR24,
+                            SWS_BILINEAR, nullptr, nullptr, nullptr
+                        ));
+                        swsSrcFmt = srcFmt;
+                        if (!swsCtx) {
+                            JARK_LOG("Failed to create SwsContext for pixel format: {}", (int)srcFmt);
+                            continue;
+                        }
+                    }
+
+                    int scaledRows = sws_scale(swsCtx.get(), frame->data, frame->linesize, 0, srcHeight,
+                        rgbFrame->data, rgbFrame->linesize);
+                    if (scaledRows <= 0) {
+                        JARK_LOG("Failed to convert video frame: {} rows scaled", scaledRows);
+                        continue;
+                    }
+
+                    // 10. 创建 cv::Mat (注意：OpenCV 使用 BGR)
+                    // 数据是连续的，直接封装
+                    cv::Mat decodedMat(dstHeight, dstWidth, CV_8UC3, rgbFrame->data[0]);
+
+                    // 深拷贝数据，因为 rgbBuffer 会在下一帧被覆盖
+                    cv::Mat finalMat = decodedMat.clone();
+
+                    // 11. 处理旋转
+                    if (rotation != 0) {
+                        int cvRotateCode = -1;
+                        int normRot = (rotation % 360 + 360) % 360;
+
+                        if (normRot == 90) {
+                            cvRotateCode = cv::ROTATE_90_CLOCKWISE;
+                        }
+                        else if (normRot == 180) {
+                            cvRotateCode = cv::ROTATE_180;
+                        }
+                        else if (normRot == 270) {
+                            cvRotateCode = cv::ROTATE_90_COUNTERCLOCKWISE;
+                        }
+
+                        if (cvRotateCode >= 0) {
+                            cv::rotate(finalMat, finalMat, cvRotateCode);
+                        }
+                    }
+
+                    frames.push_back(std::move(finalMat));
+                }
             }
         }
         av_packet_unref(packet.get());


### PR DESCRIPTION
- 修复动画播放计时：切换帧时保留剩余间隔并按帧延迟累进推进，解决 Windows 定时粒度导致的慢放；动画起播/恢复时重置计时起点，消除加载耗时造成首帧长时间停顿
- DJI 实况照片兼容：在期望偏移附近搜索合法 MP4 ftyp 盒定位内嵌视频起点，兼容视频后附加尾块的导出文件
- 视频解码：按解码首帧的实际像素格式延迟创建颜色转换上下文，跳过异常帧并继续解码后续数据包，提高容错性